### PR TITLE
Fix semantic version limit - remove last digit from version so that t…

### DIFF
--- a/tests/terratest/example/versions.tf
+++ b/tests/terratest/example/versions.tf
@@ -1,4 +1,4 @@
-# Pin exact version of azurerm provider from 3.17.0 up to 4.x
+# Pin exact version of azurerm provider from 3.17.0 up to <4.0
 # This is to inform the pre-commit hook that this module must be using older version of the azurerm instead of latest
 # So that we do not get errors due ot deprecated properties and other issues that can only be resolved by azurerm upgrade
 # Simple upgrade is not possible because bunch of upstream repositories/pipelines that use this module are still on the old azurerm provider and upgrade in this module breaks them
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.17.0"
+      version = "~> 3.17"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
-# Pin exact version of azurerm provider from 3.17.0 up to 4.x
+# Pin exact version of azurerm provider from 3.17.0 up to <4.0
 # This is to inform the pre-commit hook that this module must be using older version of the azurerm instead of latest
 # So that we do not get errors due ot deprecated properties and other issues that can only be resolved by azurerm upgrade
 # Simple upgrade is not possible because bunch of upstream repositories/pipelines that use this module are still on the old azurerm provider and upgrade in this module breaks them
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.17.0"
+      version = "~> 3.17"
     }
   }
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32530

### Change description

Remove last digit from the semver config - `~>` means last digit is allowed to be incremented.
So `~> 3.17` allows to below `4.0` while `~> 3.17.0` only allows to below `3.18`.
Upstream postgresql pipeline uses 3.113 so this module must allow for the former.

### Testing done

I run the target upstream pipeline using this branch for a module and the issue is gone:

https://dev.azure.com/hmcts-cpp/cpp-apps/_build/results?buildId=643024&view=logs&j=fa9a36d7-6310-54b1-75ed-450144bf418a&t=455d348e-1e69-50b7-a137-1304346650db

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
